### PR TITLE
Patch/ts

### DIFF
--- a/code/ec-sim-zs/utils/driver.py
+++ b/code/ec-sim-zs/utils/driver.py
@@ -172,12 +172,12 @@ def milliTS():
 
 if __name__ == "__main__":
     # TODO -- should use argparse to set values of these slices or read from config file
-    miners = [10, 20]#50, 100, 200, 400]
-    lbps = [1, 10]#, 20, 50, 100]
+    miners = [10, 20, 50, 100, 200, 300]
+    lbps = [1, 10, 20, 50, 100]
     trials = 3
-    rounds = 200
-    # sweepDir = "/home/snarky/space/ec-sim/output/sweep-f"
-    sweepDir = "./output/sweep-f"
+    rounds = 500
+    sweepDir = "/home/snarky/space/ec-sim/output/sweep-f"
+    # sweepDir = "./output/sweep-f"
 
     # TODO -- shoulduse argparse to express which operations should be done:
     #   run simulation and output (sweepByMinersAndLBP), plot existing data 
@@ -202,5 +202,5 @@ if __name__ == "__main__":
     400 rounds, 400 miners ===> 40m"""
     )
 
-    # sweepByMinersAndLBP(miners, lbps, trials, rounds, sweepDir)
-    plotSweep(miners, lbps, ["NumReorgs", "LenReorgs"], sweepDir, rounds)
+    sweepByMinersAndLBP(miners, lbps, trials, rounds, sweepDir)
+    # plotSweep(miners, lbps, ["NumReorgs", "LenReorgs"], sweepDir, rounds)


### PR DESCRIPTION
Spot check please:

we had made a mistake in how the sim treated tipsets, whereby null blocks were used as tipsets (breaking the abstraction that they are just more tickets in the array).

The consequence here was this:

take blocks C and D, both mined on top of a null block, themselves both mined on top of a tipset made of blocks A and B. C and D can be assembled into a tipset by a new block E but were not as E was seeing their parents as the null blocks rather than A and B. 

The rule is in fact:
- Tipsets are only composed of live blocks
- Tipsets are composed of live blocks who share parents AND were mined in the same round

Replaced this.